### PR TITLE
Add basepath to config for proxies

### DIFF
--- a/molten/defaults.yaml
+++ b/molten/defaults.yaml
@@ -2,6 +2,7 @@
 # vim: ft=yaml
 molten:
   install_dir: '/opt'
+  url_basepath: ''
   api_package: 'salt-api'
   api_service: 'salt-api'
   api_config: '/etc/salt/master.d/api.conf'

--- a/molten/files/api.conf.jinja
+++ b/molten/files/api.conf.jinja
@@ -16,6 +16,6 @@ rest_cherrypy:
   debug: True
   disable_ssl: True
   static: {{ molten.install_dir }}/molten
-  static_path: /assets
+  static_path: {{ molten.url_basepath }}/assets
   app: {{ molten.install_dir }}/molten/index.html
   app_path: /molten


### PR DESCRIPTION
I am using nginx as proxy and we need a basepath for salt-api.